### PR TITLE
Add support for persistent alert banners

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ Adds a new collapsiple alert banner block so that alert banners can be collapsed
 ## Cavets
 
 This is an experimental module.
-Currently this won't support the banners that need to be peristant (where remove hide button is selected). To support those banners, a different alert banner type should be created and those banners should be displayed with the default alert banner block.
+Alert banners where the field 'remove_hide_link' is set will be displayed in a persistent alerts section above the collapsible block.
+This currently won't set the hide-alert-banner-token cookie, and has no means of determining if a user has already seen an alert banner.
 
 ## Dependencies
 

--- a/localgov_alert_banner_collapsible.module
+++ b/localgov_alert_banner_collapsible.module
@@ -14,6 +14,7 @@ function localgov_alert_banner_collapsible_theme(): array {
       'variables' => [
         'control' => NULL,
         'banners' => NULL,
+        'persistent_banners' => NULL,
         'html_id' => NULL,
         'count' => NULL,
         'summary' => NULL,

--- a/src/Plugin/Block/AlertBannerCollapsibleBlock.php
+++ b/src/Plugin/Block/AlertBannerCollapsibleBlock.php
@@ -102,13 +102,16 @@ class AlertBannerCollapsibleBlock extends AlertBannerBlock {
     $html_id = Html::getUniqueId('localgov-alert-banner-collapsible');
     $build['#html_id'] = $html_id;
 
+    // Library.
     $build['#attached']['library'][] = 'localgov_alert_banner_collapsible/alert_banner_collapsible';
 
+    // Closed and open labels.
     $closed_label = $this->configuration['closed_label'] ?? self::INITIAL_CLOSED_LABEL;
     $open_label = $this->configuration['open_label'] ?? self::INITIAL_OPEN_LABEL;
     $build['#closed_label'] = $closed_label;
     $build['#open_label'] = $open_label;
 
+    // Control button.
     $build['#control'] = [
       '#type' => 'html_tag',
       '#tag' => 'button',
@@ -126,16 +129,34 @@ class AlertBannerCollapsibleBlock extends AlertBannerBlock {
 
     // Render the alert banners.
     $banner_titles = [];
+    $build['#persistent_banners'] = [];
+    $build['#banners'] = [];
     foreach ($published_alert_banners as $alert_banner) {
-      $build['#banners'][] = $this->entityTypeManager->getViewBuilder('localgov_alert_banner')
+      $rendered_banner = $this->entityTypeManager->getViewBuilder('localgov_alert_banner')
         ->view($alert_banner);
-      $banner_titles[] = $alert_banner->label();
+
+      // Group alert banners depending on if the banner should be persitently 
+      // displayed (nominally the hide link was disabled). 
+      // If so, place in the peristent banners area.
+      if ($alert_banner->hasField('remove_hide_link') && $alert_banner->remove_hide_link->value) {
+        $build['#persistent_banners'][] = $rendered_banner;
+      }
+
+      // Otherwise the banner should be in the collapsible section.
+      // Add the banner title so the summary of collapsed banners 
+      // can be generated.
+      else {
+        $build['#banners'][] = $rendered_banner;
+        $banner_titles[] = $alert_banner->label();
+      }
+      
     }
 
-    $build['#count'] = count($published_alert_banners);
+    $build['#count'] = count($build['#banners']);
     $build['#published_alert_banners'] = $published_alert_banners;
     $build['#banner_titles'] = $banner_titles;
     
+    // Summarise the banners based on the title.
     if (count($banner_titles) === 1) {
       $build['#summary'] = reset($banner_titles);
     }

--- a/templates/localgov-alert-banner-collapsible.html.twig
+++ b/templates/localgov-alert-banner-collapsible.html.twig
@@ -6,6 +6,7 @@
  * Available variables:
  * - control: Collapsible alert banner control button.
  * - banners: Rendered alert banners.
+ * - persistent_banners: Alert banners that should always be displayed.
  * - html_id: Helper html ID prefix.
  * - count: Number of alert banners being displayed.
  * - summary: Summary of alert banners.
@@ -19,11 +20,18 @@
  * @ingroup themeable
  */
 #}
-<div class="localgov-alert-banner-collapsible-pane js-alert-banner-pane" id="{{ html_id }}">
-  <span>{{ count }} notifications: </span>
-  <span>{{ summary }}</span>
-  {{ control }}
-  <div class="localgov-alert-banner-collapsible-pane--content js-alert-banner-pane-content" id="{{ html_id }}--contents">
-    {{ banners }}
+{% if persistent_banners %}
+  <div class="localgov-alert-banner-peristant-banners">
+    {{ persistent_banners }}
   </div>
-</div>
+{% endif %}
+{% if banners %}
+  <div class="localgov-alert-banner-collapsible-pane js-alert-banner-pane" id="{{ html_id }}">
+    <span>{{ count }} notifications: </span>
+    <span>{{ summary }}</span>
+    {{ control }}
+    <div class="localgov-alert-banner-collapsible-pane--content js-alert-banner-pane-content" id="{{ html_id }}--contents">
+      {{ banners }}
+    </div>
+  </div>
+{% endif %}


### PR DESCRIPTION
Fix #1
When the field hide_alert_token is set, show the alert banner above the collapsible
block. Provides a seperate secion, persistent_banners, to show them.
Remove those banners from the notification count.
Updates readme.
