### PR TITLE
Allow the default state of the collapsible banner to be set

### DIFF
--- a/js/alert_banner_collapsible.js
+++ b/js/alert_banner_collapsible.js
@@ -16,13 +16,20 @@
           const contents = pane.querySelectorAll('.js-alert-banner-pane-content')[0];
           
           // Get current state.
-          let state = window.localStorage.getItem('localgovAlertBannerCollapsibleState');
+          let state = window.localStorage.getItem('localgovAlertBannerCollapsibleState') ?? drupalSettings.localgov_alert_banner_collapsible.default_state;
           
           // Hide if default closed.
           if (state == 0) {
             contents.classList.add('hidden');
             button.setAttribute('aria-expanded', 'false');
             button.textContent = button.dataset.closedLabel;
+          }
+
+          // Else set as open.
+          else {
+            contents.classList.remove('hidden');
+            button.setAttribute('aria-expanded', 'true');
+            button.textContent = button.dataset.openLabel;
           }
 
           // Remove the hide buttons is JS

--- a/localgov_alert_banner_collapsible.module
+++ b/localgov_alert_banner_collapsible.module
@@ -22,6 +22,7 @@ function localgov_alert_banner_collapsible_theme(): array {
         'open_label' => NULL,
         'published_alert_banners' => NULL,
         'banner_titles' => NULL,
+        'default_state' => NULL,
       ],
     ],
   ];

--- a/src/Plugin/Block/AlertBannerCollapsibleBlock.php
+++ b/src/Plugin/Block/AlertBannerCollapsibleBlock.php
@@ -35,19 +35,18 @@ class AlertBannerCollapsibleBlock extends AlertBannerBlock {
       '#title' => $this->t('Collapsible options'),
     ];
 
-    //@codingStandardsIgnoreStart
     // Default state.
-    // $form['collapsible_options']['default_state'] = [
-    //   '#type' => 'radios',
-    //   '#title' => $this->t('Initial collapsible state'),
-    //   '#options' => [
-    //     '0' => $this->t('Closed'),
-    //     '1' => $this->t('Open'),
-    //     // '2' => $this->t('Open for new banners'),
-    //   ],
-    //   '#default_value' => $this->configuration['default_state'] ?? self::INITIAL_STATE,
-    // ];.
-    //@codingStandardsIgnoreEnd
+    $form['collapsible_options']['default_state'] = [
+      '#type' => 'radios',
+      '#title' => $this->t('Default state'),
+      '#options' => [
+        '0' => $this->t('Closed'),
+        '1' => $this->t('Open'),
+        // '2' => $this->t('Open for new banners'),
+      ],
+      '#default_value' => $this->configuration['default_state'] ?? self::INITIAL_STATE,
+    ];
+
     // Open label.
     $form['collapsible_options']['open_label'] = [
       '#type' => 'textfield',
@@ -106,8 +105,11 @@ class AlertBannerCollapsibleBlock extends AlertBannerBlock {
     $build['#attached']['library'][] = 'localgov_alert_banner_collapsible/alert_banner_collapsible';
 
     // Closed and open labels.
+    $default_state = $this->configuration['default_state'] ?? self::INITIAL_STATE;
     $closed_label = $this->configuration['closed_label'] ?? self::INITIAL_CLOSED_LABEL;
     $open_label = $this->configuration['open_label'] ?? self::INITIAL_OPEN_LABEL;
+    $build['#default_state'] = $default_state;
+    $build['#attached']['drupalSettings']['localgov_alert_banner_collapsible']['default_state'] = $default_state;
     $build['#closed_label'] = $closed_label;
     $build['#open_label'] = $open_label;
 
@@ -115,12 +117,12 @@ class AlertBannerCollapsibleBlock extends AlertBannerBlock {
     $build['#control'] = [
       '#type' => 'html_tag',
       '#tag' => 'button',
-      '#value' => $open_label,
+      '#value' => $default_state ? $open_label : $closed_label,
       '#attributes' => [
         'class' => [
           'js-alert-banner-pane-button',
         ],
-        'aria-expanded' => 'true',
+        'aria-expanded' => $default_state ? 'true' : 'false',
         'aria-controls' => $html_id . '--contents',
         'data-closed-label' => $closed_label,
         'data-open-label' => $open_label,
@@ -135,27 +137,27 @@ class AlertBannerCollapsibleBlock extends AlertBannerBlock {
       $rendered_banner = $this->entityTypeManager->getViewBuilder('localgov_alert_banner')
         ->view($alert_banner);
 
-      // Group alert banners depending on if the banner should be persitently 
-      // displayed (nominally the hide link was disabled). 
+      // Group alert banners depending on if the banner should be persitently
+      // displayed (nominally the hide link was disabled).
       // If so, place in the peristent banners area.
       if ($alert_banner->hasField('remove_hide_link') && $alert_banner->remove_hide_link->value) {
         $build['#persistent_banners'][] = $rendered_banner;
       }
 
       // Otherwise the banner should be in the collapsible section.
-      // Add the banner title so the summary of collapsed banners 
+      // Add the banner title so the summary of collapsed banners
       // can be generated.
       else {
         $build['#banners'][] = $rendered_banner;
         $banner_titles[] = $alert_banner->label();
       }
-      
+
     }
 
     $build['#count'] = count($build['#banners']);
     $build['#published_alert_banners'] = $published_alert_banners;
     $build['#banner_titles'] = $banner_titles;
-    
+
     // Summarise the banners based on the title.
     if (count($banner_titles) === 1) {
       $build['#summary'] = reset($banner_titles);

--- a/templates/localgov-alert-banner-collapsible.html.twig
+++ b/templates/localgov-alert-banner-collapsible.html.twig
@@ -30,7 +30,7 @@
     <span>{{ count }} notifications: </span>
     <span>{{ summary }}</span>
     {{ control }}
-    <div class="localgov-alert-banner-collapsible-pane--content js-alert-banner-pane-content" id="{{ html_id }}--contents">
+    <div class="localgov-alert-banner-collapsible-pane--content js-alert-banner-pane-content{% if default_state == 0 %} hidden{% endif %}" id="{{ html_id }}--contents">
       {{ banners }}
     </div>
   </div>


### PR DESCRIPTION
Fix #3

Uncomments the form lines to allow the alert banner to be set, and implement
the logic in the block, template and javascript.
