### PR TITLE
Rename the template variables to alert_banners

### DIFF
--- a/localgov_alert_banner_collapsible.module
+++ b/localgov_alert_banner_collapsible.module
@@ -13,15 +13,15 @@ function localgov_alert_banner_collapsible_theme(): array {
     'localgov_alert_banner_collapsible' => [
       'variables' => [
         'control' => NULL,
-        'banners' => NULL,
-        'persistent_banners' => NULL,
+        'alert_banners' => NULL,
+        'persistent_alert_banners' => NULL,
         'html_id' => NULL,
         'count' => NULL,
         'summary' => NULL,
         'closed_label' => NULL,
         'open_label' => NULL,
         'published_alert_banners' => NULL,
-        'banner_titles' => NULL,
+        'alert_banner_titles' => NULL,
         'default_state' => NULL,
       ],
     ],

--- a/src/Plugin/Block/AlertBannerCollapsibleBlock.php
+++ b/src/Plugin/Block/AlertBannerCollapsibleBlock.php
@@ -141,8 +141,8 @@ class AlertBannerCollapsibleBlock extends AlertBannerBlock {
 
     // Render the alert banners.
     $banner_titles = [];
-    $build['#persistent_banners'] = [];
-    $build['#banners'] = [];
+    $build['#persistent_alert_banners'] = [];
+    $build['#alert_banners'] = [];
     foreach ($published_alert_banners as $alert_banner) {
       $rendered_banner = $this->entityTypeManager->getViewBuilder('localgov_alert_banner')
         ->view($alert_banner);
@@ -151,22 +151,22 @@ class AlertBannerCollapsibleBlock extends AlertBannerBlock {
       // displayed (nominally the hide link was disabled).
       // If so, place in the peristent banners area.
       if ($alert_banner->hasField('remove_hide_link') && $alert_banner->remove_hide_link->value) {
-        $build['#persistent_banners'][] = $rendered_banner;
+        $build['#persistent_alert_banners'][] = $rendered_banner;
       }
 
       // Otherwise the banner should be in the collapsible section.
       // Add the banner title so the summary of collapsed banners
       // can be generated.
       else {
-        $build['#banners'][] = $rendered_banner;
+        $build['#alert_banners'][] = $rendered_banner;
         $banner_titles[] = $alert_banner->label();
       }
 
     }
 
-    $build['#count'] = count($build['#banners']);
+    $build['#count'] = count($build['#alert_banners']);
     $build['#published_alert_banners'] = $published_alert_banners;
-    $build['#banner_titles'] = $banner_titles;
+    $build['#alert_banner_titles'] = $banner_titles;
 
     // Summarise the banners based on the title.
     // Use the configured value to show a summary, which is the max number of

--- a/templates/localgov-alert-banner-collapsible.html.twig
+++ b/templates/localgov-alert-banner-collapsible.html.twig
@@ -5,33 +5,35 @@
  *
  * Available variables:
  * - control: Collapsible alert banner control button.
- * - banners: Rendered alert banners.
- * - persistent_banners: Alert banners that should always be displayed.
+ * - alert_banners: Rendered alert banners.
+ * - persistent_alert_banners: Alert banners that should always be displayed.
  * - html_id: Helper html ID prefix.
  * - count: Number of alert banners being displayed.
  * - summary: Summary of alert banners.
  * - closed_label: Label to use when the collapsible pane is closed.
  * - open_label: Label to use when the collapsible pane is open.
  * - published_alert_banners: Array of alert banner entities.
- * - banner_titles: Array of alert banner titles.
+ * - alert_banner_titles: Array of alert banner titles in the collapsible block.
+ * - default_state: Indicator of the default state of the alert banner when no
+ *   action has been taken. 0 = closed, 1 = open.
  *
  * @see template_preprocess_localgov_alert_banner_collapsible()
  *
  * @ingroup themeable
  */
 #}
-{% if persistent_banners %}
+{% if persistent_alert_banners %}
   <div class="localgov-alert-banner-peristant-banners">
-    {{ persistent_banners }}
+    {{ persistent_alert_banners }}
   </div>
 {% endif %}
-{% if banners %}
+{% if alert_banners %}
   <div class="localgov-alert-banner-collapsible-pane js-alert-banner-pane" id="{{ html_id }}">
     <span>{{ count }} notifications: </span>
     <span>{{ summary }}</span>
     {{ control }}
     <div class="localgov-alert-banner-collapsible-pane--content js-alert-banner-pane-content{% if default_state == 0 %} hidden{% endif %}" id="{{ html_id }}--contents">
-      {{ banners }}
+      {{ alert_banners }}
     </div>
   </div>
 {% endif %}


### PR DESCRIPTION
Fix #7

This is to align with the main modules convention.
(alert_banners not banners).
