### PR TITLE
Fix WSOD when collapsible block placed with no alert banners

### DIFF
--- a/config/schema/localgov_alert_banner_collapsible.schema.yml
+++ b/config/schema/localgov_alert_banner_collapsible.schema.yml
@@ -1,0 +1,21 @@
+block.settings.localgov_alert_banner_collapsible:
+  type: block_settings
+  label: 'LocalGov alert banner collapsible settings'
+  mapping:
+    include_types:
+      type: sequence
+      label: 'Displayed alert types'
+      sequence:
+        type: string
+    default_state:
+      type: integer
+      label: 'Default state'
+    open_label:
+      type: string
+      label: 'Open label'
+    closed_label:
+      type: string
+      label: 'Closed label'
+    max_titles_before_summary:
+      type: integer
+      label: 'Titles to display before before showing a summary.'

--- a/src/Plugin/Block/AlertBannerCollapsibleBlock.php
+++ b/src/Plugin/Block/AlertBannerCollapsibleBlock.php
@@ -89,7 +89,7 @@ class AlertBannerCollapsibleBlock extends AlertBannerBlock {
   /**
    * {@inheritdoc}
    */
-  public function build(): array {
+  public function build(): ?array {
 
     $options = [
       'type' => $this->mapTypesConfigToQuery(),

--- a/tests/src/Functional/BlockDisplayTest.php
+++ b/tests/src/Functional/BlockDisplayTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Drupal\Tests\localgov_alert_banner_collapsible\Functional;
 
 use Drupal\Tests\BrowserTestBase;
-use Drupal\block\Entity\Block;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -37,7 +36,7 @@ final class BlockDisplayTest extends BrowserTestBase {
   public function testBlockDisplays(): void {
     $admin_user = $this->drupalCreateUser(['administer blocks']);
     $this->drupalLogin($admin_user);
-    $block = $this->drupalPlaceBlock('localgov_alert_banner_collapsible');
+    $this->drupalPlaceBlock('localgov_alert_banner_collapsible');
     $this->drupalLogout();
 
     // Check hide link is shown when remove_hide_link is not set.

--- a/tests/src/Functional/BlockDisplayTest.php
+++ b/tests/src/Functional/BlockDisplayTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\localgov_alert_banner_collapsible\Functional;
+
+use Drupal\Tests\BrowserTestBase;
+use Drupal\block\Entity\Block;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Test collapsible block displays when positioned.
+ *
+ * @group localgov_alert_banner_collapsible
+ */
+final class BlockDisplayTest extends BrowserTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $defaultTheme = 'stark';
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'block',
+    'path',
+    'options',
+    'localgov_alert_banner',
+    'localgov_alert_banner_collapsible',
+  ];
+
+  /**
+   * Test callback.
+   */
+  public function testBlockDisplays(): void {
+    $admin_user = $this->drupalCreateUser(['administer blocks']);
+    $this->drupalLogin($admin_user);
+    $block = $this->drupalPlaceBlock('localgov_alert_banner_collapsible');
+    $this->drupalLogout();
+
+    // Check hide link is shown when remove_hide_link is not set.
+    $this->drupalGet('<front>');
+
+    // Assert page displays ok.
+    // @See https://github.com/localgovdrupal/localgov_alert_banner_collapsible/issues/21
+    $this->assertSession()->statusCodeEquals(Response::HTTP_OK);
+  }
+
+}


### PR DESCRIPTION
Fix #21 
Also FIx #18 

Note: This includes only a basic test to verify the block is placed and does not cause an error 500.
Further tests will be needed in follow up PRs (see #16).
